### PR TITLE
feat: add semantic-release with conventional commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - rc/*
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cycjimmy/semantic-release-action@v6.0.0
+        with:
+          extra_plugins: |
+            conventional-changelog-conventionalcommits
+            @semantic-release/exec
+        env:
+          FORCE_COLOR: 1
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          cache: pnpm
       - uses: cycjimmy/semantic-release-action@v6.0.0
         with:
           extra_plugins: |

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,24 @@
+plugins:
+  - - '@semantic-release/commit-analyzer'
+    - preset: 'conventionalcommits'
+  - - '@semantic-release/release-notes-generator'
+    - preset: 'conventionalcommits'
+  - - '@semantic-release/github'
+    - successCommentCondition: false
+
+  # Update dist, in case Dependabot PRs merged without doing so
+  - - '@semantic-release/exec'
+    - prepareCmd: 'pnpm install && pnpm run build'
+
+  - - '@semantic-release/git'
+    - assets:
+        - 'dist/**'
+        - 'package.json' # commit updated version back to source
+      message: 'chore(release): update dist and package.json'
+
+  - '@semantic-release/npm'
+
+branches:
+  - main
+  - name: rc/*
+    prerelease: '${name.replace(/^rc\//, "rc-")}'

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -10,13 +10,12 @@ plugins:
   - - '@semantic-release/exec'
     - prepareCmd: 'pnpm install && pnpm run build'
 
+  - - '@semantic-release/npm'
+
   - - '@semantic-release/git'
     - assets:
         - 'dist/**'
-        - 'package.json' # commit updated version back to source
-      message: 'chore(release): update dist and package.json'
-
-  - '@semantic-release/npm'
+      message: 'chore(release): update dist'
 
 branches:
   - main

--- a/README.md
+++ b/README.md
@@ -10,13 +10,7 @@ pnpm add @freckle/cancelable-promise
 
 ## Release
 
-To trigger a release in this project, merge a commit to `main` prefixed with:
-
-1. `fix:` to trigger a patch release,
-1. `feat:` to trigger minor, or
-1. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
-
-See [RELEASE.md](./RELEASE.md) for more details.
+See [RELEASE.md](./RELEASE.md).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ Utilities to create a promise that can be canceled.
 pnpm add @freckle/cancelable-promise
 ```
 
-## Versioning and release process
+## Release
 
-See [RELEASE.md](./RELEASE.md).
+To trigger a release in this project, merge a commit to `main` prefixed with:
+
+1. `fix:` to trigger a patch release,
+1. `feat:` to trigger minor, or
+1. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
+
+See [RELEASE.md](./RELEASE.md) for more details.
 
 ## Usage
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,34 +1,14 @@
-# Releases
+# Release
 
-## Versioning
+This project uses [semantic-release](https://github.com/semantic-release/semantic-release)
+with [conventional commits](https://www.conventionalcommits.org/) to trigger releases.
 
-Versioned tags will exist, such as `v1.0.0` and `v2.1.1`. Branches will exist
-for each major version, such as `v1` or `v2` and contain the newest version in
-that series.
+To trigger a release in this project, merge a commit to `main` prefixed with:
 
-## Release process
+1. `fix:` to trigger a patch release,
+1. `feat:` to trigger minor, or
+1. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
 
-Given a latest version of v1.0.1,
+Pre-releases can be made by pushing to an `rc/*` branch.
 
-Is this a new major version?
-
-If yes,
-
-```console
-git checkout main
-git pull
-git checkout -b v2
-git tag -s -m v2.0.0 v2.0.0
-git push --follow-tags
-```
-
-Otherwise,
-
-```console
-git checkout main
-git pull
-git checkout v1
-git merge --ff-only -
-git tag -s -m v1.0.2 v1.0.2    # or v1.1.0
-git push --follow-tags
-```
+For more details, see the [Semantic Release](https://illuminate.atlassian.net/wiki/spaces/PENG/pages/17952735277/Semantic+Release) documentation.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,8 +6,8 @@ with [conventional commits](https://www.conventionalcommits.org/) to trigger rel
 To trigger a release in this project, merge a commit to `main` prefixed with:
 
 1. `fix:` to trigger a patch release,
-1. `feat:` to trigger minor, or
-1. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
+2. `feat:` to trigger minor, or
+3. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
 
 Pre-releases can be made by pushing to an `rc/*` branch.
 


### PR DESCRIPTION
## Summary

- Add semantic-release configuration (`.releaserc.yaml`) with `conventionalcommits` preset, NPM publish, and GitHub release plugins
- Add `release.yml` workflow using `cycjimmy/semantic-release-action@v6.0.0`
- Support `rc/*` branches for pre-releases
- Replace manual tag-based release process in `RELEASE.md` and `README.md` with conventional commit instructions
- Uses `pnpm` for build command in `.releaserc.yaml` (matching this repo's package manager)

## Prerequisites

Before merging, ensure:
- [ ] `NPM_TOKEN` secret is configured on the repo for NPM publishing
- [ ] Repository rulesets have a bypass configured for the release bot (if applicable)

## Test plan

- [ ] Verify YAML syntax is valid for `.releaserc.yaml` and `release.yml`
- [ ] Confirm CI workflow passes on this PR
- [ ] After merge, verify a release is triggered with the `feat:` commit prefix
- [ ] Test pre-release flow by pushing to an `rc/*` branch

Mirrors freckle/i18n-scripts-js#21