### PR TITLE
feat: add semantic-release with conventional commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - rc/*
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          cache: pnpm
+      - uses: cycjimmy/semantic-release-action@v6.0.0
+        with:
+          extra_plugins: |
+            conventional-changelog-conventionalcommits
+            @semantic-release/exec
+        env:
+          FORCE_COLOR: 1
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,19 @@
+plugins:
+  - - '@semantic-release/commit-analyzer'
+    - preset: 'conventionalcommits'
+  - - '@semantic-release/release-notes-generator'
+    - preset: 'conventionalcommits'
+  - - '@semantic-release/github'
+    - successCommentCondition: false
+
+  # Build dist fresh for each release; not committed back to the repo
+  # (npm packs whatever is on disk via the "files" allowlist in package.json)
+  - - '@semantic-release/exec'
+    - prepareCmd: 'pnpm install && pnpm run build'
+
+  - - '@semantic-release/npm'
+
+branches:
+  - main
+  - name: rc/*
+    prerelease: '${name.replace(/^rc\//, "rc-")}'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Utilities to create a promise that can be canceled.
 pnpm add @freckle/cancelable-promise
 ```
 
-## Versioning and release process
+## Release
 
 See [RELEASE.md](./RELEASE.md).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,34 +1,14 @@
-# Releases
+# Release
 
-## Versioning
+This project uses [semantic-release](https://github.com/semantic-release/semantic-release)
+with [conventional commits](https://www.conventionalcommits.org/) to trigger releases.
 
-Versioned tags will exist, such as `v1.0.0` and `v2.1.1`. Branches will exist
-for each major version, such as `v1` or `v2` and contain the newest version in
-that series.
+To trigger a release in this project, merge a commit to `main` prefixed with:
 
-## Release process
+1. `fix:` to trigger a patch release,
+2. `feat:` to trigger minor, or
+3. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
 
-Given a latest version of v1.0.1,
+Pre-releases can be made by pushing to an `rc/*` branch.
 
-Is this a new major version?
-
-If yes,
-
-```console
-git checkout main
-git pull
-git checkout -b v2
-git tag -s -m v2.0.0 v2.0.0
-git push --follow-tags
-```
-
-Otherwise,
-
-```console
-git checkout main
-git pull
-git checkout v1
-git merge --ff-only -
-git tag -s -m v1.0.2 v1.0.2    # or v1.1.0
-git push --follow-tags
-```
+For more details, see the [Semantic Release](https://illuminate.atlassian.net/wiki/spaces/PENG/pages/17952735277/Semantic+Release) documentation.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "Freckle",
   "license": "MIT",
   "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freckle/cancelable-promise-js.git"


### PR DESCRIPTION
## Summary

Reopens #152 (closed when the branch was renamed to `rc/semantic-release` to exercise the `rc/*` pre-release workflow).

- Add `.releaserc.yaml` with `conventionalcommits` preset, NPM publish, and GitHub release plugins
- Add `release.yml` workflow using `cycjimmy/semantic-release-action@v6.0.0`
- Support `rc/*` branches for pre-releases
- Replace manual tag-based release process in `RELEASE.md` / `README.md` with conventional-commit instructions
- Uses `pnpm` for the build step (matches the repo's package manager)

## Review feedback from #152

- **`package.json` `files` field** — added `"files": ["dist"]` so npm only ships built output (no workflows, config, lockfile, source, etc.)
- **`@semantic-release/git` + ruleset / app-token concern** — removed the plugin entirely. `dist/` is rebuilt fresh on every release via `@semantic-release/exec` and packed from disk by `@semantic-release/npm` (using the new `files` allowlist), so there's no need to commit anything back to `main` and no ruleset bypass is required. Default `GITHUB_TOKEN` is sufficient.
- **pnpm setup in release workflow** — already added (`pnpm/action-setup@v6` + `actions/setup-node@v6` with `cache: pnpm`) so `pnpm install && pnpm run build` works on first release.

## Prerequisites

Before merging, confirm:
- [ ] `NPM_TOKEN` secret is configured on the repo for NPM publishing (which token to use for `@freckle/*` publish?)

## Test plan

- [ ] Verify YAML is valid for `.releaserc.yaml` and `release.yml`
- [ ] CI passes on this PR
- [ ] After merge, a release is triggered by a `feat:` / `fix:` commit on `main`
- [ ] Pre-release flow verified by push to `rc/semantic-release-v2` (this branch)
- [ ] `npm pack` tarball contents limited to `dist/` + metadata files

Mirrors freckle/i18n-scripts-js#21.